### PR TITLE
App routes add medical advice

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -208,6 +208,7 @@ def register_blueprints():
     from routes.profile.documents import documents_bp
     from routes.profile.sub_profiles import sub_profile_bp
     from routes.ordonnances.ordonnance_create import ordonnances_bp
+    from routes.medicine.get_medical_advice import get_medical_advice_bp
 
     # Save blueprints
     app.register_blueprint(find_doctor_by_name_bp)
@@ -263,6 +264,8 @@ def register_blueprints():
     app.register_blueprint(clickcollect_temp_images_bp)
     app.register_blueprint(ordonnances_bp)
     app.register_blueprint(documents_bp)
+    app.register_blueprint(get_medical_advice_bp)
+
 
 register_blueprints()
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -209,6 +209,10 @@ def register_blueprints():
     from routes.profile.sub_profiles import sub_profile_bp
     from routes.ordonnances.ordonnance_create import ordonnances_bp
     from routes.medicine.get_medical_advice import get_medical_advice_bp
+    from routes.ordonnances.ordonnance_create_from_ocr import ordonnance_ocr_create_bp
+    from routes.ordonnances.get_non_verified_ordonnances import get_non_verified_ordonnances_bp
+    from routes.ordonnances.verify_ordonnance import verify_ordonnance_bp
+
 
     # Save blueprints
     app.register_blueprint(find_doctor_by_name_bp)
@@ -265,6 +269,10 @@ def register_blueprints():
     app.register_blueprint(ordonnances_bp)
     app.register_blueprint(documents_bp)
     app.register_blueprint(get_medical_advice_bp)
+    app.register_blueprint(ordonnance_ocr_create_bp)
+    app.register_blueprint(get_non_verified_ordonnances_bp)
+    app.register_blueprint(verify_ordonnance_bp)
+
 
 
 register_blueprints()

--- a/backend/medicine_available.json
+++ b/backend/medicine_available.json
@@ -1,38 +1,499 @@
-
 {
-	"medicine": [
-		{	"id": 1,	"label": "Dafalgan",		"category":	"painKiller",		"size": 2,	"price": 2.18  },
-		{	"id": 2,	"label": "Gaviscon",		"category": "antiAcid",			"size": 0,	"price": 3.04  },
-		{	"id": 3,	"label": "Nurofen",			"category":	"antiInflammatory",	"size": 1,	"price": 3.29  },
-		{	"id": 4,	"label": "Physiomer",		"category": "hygiene",			"size": 2,	"price": 10.38 },
-		{	"id": 5,	"label": "Zyrtec",			"category": "antiHistamine",	"size": 0,	"price": 3.40  },
-		{	"id": 6,	"label": "Coryzalia",		"category": "homeopathy",		"size": 0,	"price": 5.57  },
-		{	"id": 7,	"label": "Ibuprofene",		"category":	"antiInflammatory",	"size": 1,	"price": 3.18  },
-		{	"id": 8,	"label": "Doliprane",		"category":	"painKiller",		"size": 2,	"price": 2.18  },
-		{	"id": 9,	"label": "L52",				"category": "homeopathy",		"size": 3,	"price": 6.99  },
-		{	"id": 10,	"label": "Toplexil",		"category": "antiHistamine",	"size": 1,	"price": 6.00  },
-		{	"id": 11,	"label": "Vitascorbol",		"category": "foodSupplement",	"size": 3,	"price": 2.99  },
-		{	"id": 12,	"label": "Hexaspray",		"category": "antiSeptic",		"size": 3,	"price": 4.99  },
-		{	"id": 13,	"label": "Voltarene",		"category":	"antiInflammatory",	"size": 0,	"price": 4.68  },
-		{	"id": 14,	"label": "Smecta",			"category": "antiDiarrheal",	"size": 1,	"price": 3.19  },
-		{	"id": 15,	"label": "Synthol",			"category":	"painKiller",		"size": 2,	"price": 7.60  },
-		{	"id": 16,	"label": "Strepsil",		"category": "antiSeptic",		"size": 3,	"price": 7.71  },
-		{	"id": 17,	"label": "Dafalgan 2",		"category":	"painKiller",		"size": 0,	"price": 2.18  },
-		{	"id": 18,	"label": "Gaviscon 2",		"category": "antiAcid",			"size": 1,	"price": 3.04  },
-		{	"id": 19,	"label": "Nurofen 2",		"category":	"painKiller",		"size": 2,	"price": 3.29  },
-		{	"id": 20,	"label": "Physiomer 2",		"category": "hygiene",			"size": 3,	"price": 10.38 },
-		{	"id": 21,	"label": "Zyrtec 2",		"category": "antiHistamine",	"size": 0,	"price": 3.40  },
-		{	"id": 22,	"label": "Coryzalia 2",		"category": "homeopathy",		"size": 1,	"price": 5.57  },
-		{	"id": 23,	"label": "Ibuprofen 2",		"category":	"antiInflammatory",	"size": 2,	"price": 3.18  },
-		{	"id": 24,	"label": "Doliprane 2",		"category":	"painKiller",		"size": 3,	"price": 2.18  },
-		{	"id": 25,	"label": "L52 2",			"category": "homeopathy",		"size": 0,	"price": 6.99  },
-		{	"id": 26,	"label": "Toplexil 2",		"category": "antiHistamine",	"size": 1,	"price": 6.00  },
-		{	"id": 27,	"label": "Vitascorbol 2",	"category": "foodSupplement",	"size": 2,	"price": 2.99  },
-		{	"id": 28,	"label": "Hexaspray 2",		"category": "antiSeptic",		"size": 3,	"price": 4.99  },
-		{	"id": 29,	"label": "Voltaren 2",		"category":	"antiInflammatory",	"size": 0,	"price": 4.68  },
-		{	"id": 30,	"label": "Smecta 2",		"category": "antiDiarrheal",	"size": 1,	"price": 3.19  },
-		{	"id": 31,	"label": "Synthol 2",		"category":	"painKiller",		"size": 2,	"price": 7.60  },
-		{	"id": 32,	"label": "Strepsil 2",		"category": "antiSeptic",		"size": 3,	"price": 7.71  },
-		{	"id": 33,	"label": "Test Medecine",	"category":	"test",				"size": 42,	"price": 0.50  }
-	]
+    "medicine": [
+        {
+            "id": 1,
+            "label": "Dafalgan",
+            "category": "painKiller",
+            "size": 2,
+            "price": 2.18,
+            "medicalAdvice": {
+                "dosage": "1 à 2 comprimés toutes les 6 heures",
+                "maxPerDay": "3g par jour",
+                "warnings": [
+                    "Ne pas associer avec l’alcool",
+                    "Attention en cas de maladie du foie"
+                ],
+                "contraIndications": [
+                    "Insuffisance hépatique sévère"
+                ]
+            }
+        },
+        {
+            "id": 2,
+            "label": "Gaviscon",
+            "category": "antiAcid",
+            "size": 0,
+            "price": 3.04,
+            "medicalAdvice": {
+                "dosage": "10 à 20 ml après les repas et au coucher",
+                "maxPerDay": "80 ml par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’allergie à l’un des composants"
+                ],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 3,
+            "label": "Nurofen",
+            "category": "antiInflammatory",
+            "size": 1,
+            "price": 3.29,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 6 à 8 heures",
+                "maxPerDay": "1200 mg par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’asthme ou d’ulcère gastrique"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale sévère"
+                ]
+            }
+        },
+        {
+            "id": 4,
+            "label": "Physiomer",
+            "category": "hygiene",
+            "size": 2,
+            "price": 10.38,
+            "medicalAdvice": {
+                "dosage": "1 à 2 pulvérisations dans chaque narine, 2 à 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 5,
+            "label": "Zyrtec",
+            "category": "antiHistamine",
+            "size": 0,
+            "price": 3.40,
+            "medicalAdvice": {
+                "dosage": "1 comprimé par jour",
+                "maxPerDay": "1 comprimé par jour",
+                "warnings": [
+                    "Peut provoquer une somnolence"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale sévère"
+                ]
+            }
+        },
+        {
+            "id": 6,
+            "label": "Coryzalia",
+            "category": "homeopathy",
+            "size": 0,
+            "price": 5.57,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les heures, puis espacer selon amélioration",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 7,
+            "label": "Ibuprofene",
+            "category": "antiInflammatory",
+            "size": 1,
+            "price": 3.18,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 6 à 8 heures",
+                "maxPerDay": "1200 mg par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’asthme ou d’ulcère gastrique"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale sévère"
+                ]
+            }
+        },
+        {
+            "id": 8,
+            "label": "Doliprane",
+            "category": "painKiller",
+            "size": 2,
+            "price": 2.18,
+            "medicalAdvice": {
+                "dosage": "1 à 2 comprimés toutes les 6 heures",
+                "maxPerDay": "4g par jour",
+                "warnings": [
+                    "Ne pas associer avec l’alcool"
+                ],
+                "contraIndications": [
+                    "Insuffisance hépatique"
+                ]
+            }
+        },
+        {
+            "id": 9,
+            "label": "L52",
+            "category": "homeopathy",
+            "size": 3,
+            "price": 6.99,
+            "medicalAdvice": {
+                "dosage": "1 comprimé 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 10,
+            "label": "Toplexil",
+            "category": "antiHistamine",
+            "size": 1,
+            "price": 6.00,
+            "medicalAdvice": {
+                "dosage": "1 comprimé par jour",
+                "maxPerDay": "1 comprimé par jour",
+                "warnings": [
+                    "Peut provoquer une somnolence"
+                ],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 11,
+            "label": "Vitascorbol",
+            "category": "foodSupplement",
+            "size": 3,
+            "price": 2.99,
+            "medicalAdvice": {
+                "dosage": "1 comprimé par jour",
+                "maxPerDay": "1 comprimé par jour",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 12,
+            "label": "Hexaspray",
+            "category": "antiSeptic",
+            "size": 3,
+            "price": 4.99,
+            "medicalAdvice": {
+                "dosage": "1 pulvérisation 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 13,
+            "label": "Voltarene",
+            "category": "antiInflammatory",
+            "size": 0,
+            "price": 4.68,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 12 heures",
+                "maxPerDay": "100 mg par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’ulcère gastrique"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale"
+                ]
+            }
+        },
+        {
+            "id": 14,
+            "label": "Smecta",
+            "category": "antiDiarrheal",
+            "size": 1,
+            "price": 3.19,
+            "medicalAdvice": {
+                "dosage": "1 sachet 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 15,
+            "label": "Synthol",
+            "category": "painKiller",
+            "size": 2,
+            "price": 7.60,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 4 à 6 heures",
+                "maxPerDay": "3g par jour",
+                "warnings": [
+                    "Ne pas associer avec l’alcool"
+                ],
+                "contraIndications": [
+                    "Insuffisance hépatique"
+                ]
+            }
+        },
+        {
+            "id": 16,
+            "label": "Strepsil",
+            "category": "antiSeptic",
+            "size": 3,
+            "price": 7.71,
+            "medicalAdvice": {
+                "dosage": "1 pastille toutes les 2 à 3 heures",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 17,
+            "label": "Dafalgan 2",
+            "category": "painKiller",
+            "size": 0,
+            "price": 2.18,
+            "medicalAdvice": {
+                "dosage": "1 à 2 comprimés toutes les 6 heures",
+                "maxPerDay": "3g par jour",
+                "warnings": [
+                    "Ne pas associer avec l’alcool",
+                    "Attention en cas de maladie du foie"
+                ],
+                "contraIndications": [
+                    "Insuffisance hépatique sévère"
+                ]
+            }
+        },
+        {
+            "id": 18,
+            "label": "Gaviscon 2",
+            "category": "antiAcid",
+            "size": 1,
+            "price": 3.04,
+            "medicalAdvice": {
+                "dosage": "10 à 20 ml après les repas et au coucher",
+                "maxPerDay": "80 ml par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’allergie à l’un des composants"
+                ],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 19,
+            "label": "Nurofen 2",
+            "category": "painKiller",
+            "size": 2,
+            "price": 3.29,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 6 à 8 heures",
+                "maxPerDay": "1200 mg par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’asthme ou d’ulcère gastrique"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale sévère"
+                ]
+            }
+        },
+        {
+            "id": 20,
+            "label": "Physiomer 2",
+            "category": "hygiene",
+            "size": 3,
+            "price": 10.38,
+            "medicalAdvice": {
+                "dosage": "1 à 2 pulvérisations dans chaque narine, 2 à 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 21,
+            "label": "Zyrtec 2",
+            "category": "antiHistamine",
+            "size": 0,
+            "price": 3.40,
+            "medicalAdvice": {
+                "dosage": "1 comprimé par jour",
+                "maxPerDay": "1 comprimé par jour",
+                "warnings": [
+                    "Peut provoquer une somnolence"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale sévère"
+                ]
+            }
+        },
+        {
+            "id": 22,
+            "label": "Coryzalia 2",
+            "category": "homeopathy",
+            "size": 1,
+            "price": 5.57,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les heures, puis espacer selon amélioration",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 23,
+            "label": "Ibuprofen 2",
+            "category": "antiInflammatory",
+            "size": 2,
+            "price": 3.18,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 6 à 8 heures",
+                "maxPerDay": "1200 mg par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’asthme ou d’ulcère gastrique"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale sévère"
+                ]
+            }
+        },
+        {
+            "id": 24,
+            "label": "Doliprane 2",
+            "category": "painKiller",
+            "size": 3,
+            "price": 2.18,
+            "medicalAdvice": {
+                "dosage": "1 à 2 comprimés toutes les 6 heures",
+                "maxPerDay": "4g par jour",
+                "warnings": [
+                    "Ne pas associer avec l’alcool"
+                ],
+                "contraIndications": [
+                    "Insuffisance hépatique"
+                ]
+            }
+        },
+        {
+            "id": 25,
+            "label": "L52 2",
+            "category": "homeopathy",
+            "size": 0,
+            "price": 6.99,
+            "medicalAdvice": {
+                "dosage": "1 comprimé 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 26,
+            "label": "Toplexil 2",
+            "category": "antiHistamine",
+            "size": 1,
+            "price": 6.00,
+            "medicalAdvice": {
+                "dosage": "1 comprimé par jour",
+                "maxPerDay": "1 comprimé par jour",
+                "warnings": [
+                    "Peut provoquer une somnolence"
+                ],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 27,
+            "label": "Vitascorbol 2",
+            "category": "foodSupplement",
+            "size": 2,
+            "price": 2.99,
+            "medicalAdvice": {
+                "dosage": "1 comprimé par jour",
+                "maxPerDay": "1 comprimé par jour",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 28,
+            "label": "Hexaspray 2",
+            "category": "antiSeptic",
+            "size": 3,
+            "price": 4.99,
+            "medicalAdvice": {
+                "dosage": "1 pulvérisation 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 29,
+            "label": "Voltaren 2",
+            "category": "antiInflammatory",
+            "size": 0,
+            "price": 4.68,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 12 heures",
+                "maxPerDay": "100 mg par jour",
+                "warnings": [
+                    "Ne pas utiliser en cas d’ulcère gastrique"
+                ],
+                "contraIndications": [
+                    "Insuffisance rénale"
+                ]
+            }
+        },
+        {
+            "id": 30,
+            "label": "Smecta 2",
+            "category": "antiDiarrheal",
+            "size": 1,
+            "price": 3.19,
+            "medicalAdvice": {
+                "dosage": "1 sachet 3 fois par jour",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 31,
+            "label": "Synthol 2",
+            "category": "painKiller",
+            "size": 2,
+            "price": 7.60,
+            "medicalAdvice": {
+                "dosage": "1 comprimé toutes les 4 à 6 heures",
+                "maxPerDay": "3g par jour",
+                "warnings": [
+                    "Ne pas associer avec l’alcool"
+                ],
+                "contraIndications": [
+                    "Insuffisance hépatique"
+                ]
+            }
+        },
+        {
+            "id": 32,
+            "label": "Strepsil 2",
+            "category": "antiSeptic",
+            "size": 3,
+            "price": 7.71,
+            "medicalAdvice": {
+                "dosage": "1 pastille toutes les 2 à 3 heures",
+                "maxPerDay": "Pas de limite stricte",
+                "warnings": [],
+                "contraIndications": []
+            }
+        },
+        {
+            "id": 33,
+            "label": "Test Medecine",
+            "category": "test",
+            "size": 42,
+            "price": 0.50,
+            "medicalAdvice": {
+                "dosage": "1 comprimé par jour",
+                "maxPerDay": "1 comprimé par jour",
+                "warnings": [],
+                "contraIndications": []
+            }
+        }
+    ]
 }

--- a/backend/routes/medicine/get_medical_advice.py
+++ b/backend/routes/medicine/get_medical_advice.py
@@ -1,0 +1,88 @@
+from flask import Blueprint, Response
+import json
+import os
+
+get_medical_advice_bp = Blueprint(
+    "get_medical_advice",
+    __name__
+)
+
+@get_medical_advice_bp.route(
+    "/medicine/<int:medicine_id>/medical-advice",
+    methods=["GET"]
+)
+def get_medical_advice(medicine_id):
+    """
+    Objectif: Retrieve medical advice associated with a given medicine.
+
+    Parameters:
+        - medicine_id (int): medicine identifier
+    
+    Query parameters:
+        - None
+
+    Returns:
+        - 200: JSON response containing the medical advice for the specified medicine (Object)
+        - 404: JSON error response if the medicine or its advice is not found (Object)
+        - 500: JSON error response if an internal error occurs (Object)
+    """
+    try:
+        json_path = "/data/medicine_available.json"
+
+        if not os.path.exists(json_path):
+            return Response(
+                json.dumps({"error": "Medicine data file not found"}, ensure_ascii=False),
+                mimetype='application/json; charset=utf-8',
+                status=404
+            )
+
+        with open(json_path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+
+        medicines = data.get("medicine", [])
+
+        medicine = next(
+            (m for m in medicines if m.get("id") == medicine_id),
+            None
+        )
+
+        if not medicine:
+            return Response(
+                json.dumps({"error": "Medicine not found"}, ensure_ascii=False),
+                mimetype='application/json; charset=utf-8',
+                status=404
+            )
+
+        medical_advice = medicine.get("medicalAdvice")
+
+        if not medical_advice:
+            return Response(
+                json.dumps({"error": "Medical advice not available for this medicine"}, ensure_ascii=False),
+                mimetype='application/json; charset=utf-8',
+                status=404
+            )
+
+        response_data = {
+            "medicineId": medicine_id,
+            "label": medicine.get("label"),
+            "medicalAdvice": medical_advice
+        }
+
+        return Response(
+            json.dumps(response_data, ensure_ascii=False),
+            mimetype='application/json; charset=utf-8',
+            status=200
+        )
+
+    except json.JSONDecodeError:
+        return Response(
+            json.dumps({"error": "Failed to parse medicine data file"}, ensure_ascii=False),
+            mimetype='application/json; charset=utf-8',
+            status=500
+        )
+    except Exception as e:
+        return Response(
+            json.dumps({"error": str(e) or "An unknown error occurred"}, ensure_ascii=False),
+            mimetype='application/json; charset=utf-8',
+            status=500
+        )

--- a/backend/routes/ordonnances/get_non_verified_ordonnances.py
+++ b/backend/routes/ordonnances/get_non_verified_ordonnances.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, jsonify
+from db_app import get_app_connection
+import pymysql
+
+from routes.profile.profile_access import get_current_user_id
+
+get_non_verified_ordonnances_bp = Blueprint(
+    "get_non_verified_ordonnances",
+    __name__
+)
+
+@get_non_verified_ordonnances_bp.route("/ordonnances/non_verifiees", methods=["GET"])
+def get_non_verified_ordonnances():
+    current_user_id, error_response, status = get_current_user_id()
+    if error_response:
+        return error_response, status
+
+    conn = get_app_connection()
+    try:
+        with conn.cursor(pymysql.cursors.DictCursor) as cursor:
+            cursor.execute("""
+                SELECT *
+                FROM ordonnances
+                WHERE statut = 'non_verifiee'
+            """)
+            ordonnances = cursor.fetchall()
+    finally:
+        conn.close()
+
+    return jsonify(ordonnances), 200

--- a/backend/routes/ordonnances/ordonnance_create_from_ocr.py
+++ b/backend/routes/ordonnances/ordonnance_create_from_ocr.py
@@ -1,0 +1,81 @@
+from flask import Blueprint, request, jsonify
+from db_app import get_app_connection
+import pymysql
+import json
+from datetime import datetime
+
+from routes.profile.profile_access import (
+    get_current_user_id,
+    profile_target_access_condition
+)
+
+ordonnance_ocr_create_bp = Blueprint(
+    "ordonnance_ocr_create",
+    __name__
+)
+
+@ordonnance_ocr_create_bp.route("/ordonnances/create_from_ocr", methods=["POST"])
+def create_ordonnance_from_ocr():
+    current_user_id, error_response, status = get_current_user_id()
+    if error_response:
+        return error_response, status
+
+    data = request.get_json()
+    user_id = data.get("user_id")
+    infos_ocr = data.get("infos_ocr")
+
+    if not user_id or not infos_ocr:
+        return jsonify({"error": "Missing user_id or infos_ocr"}), 400
+
+    conn = get_app_connection()
+    try:
+        with conn.cursor() as cursor:
+            condition = profile_target_access_condition("id")
+            cursor.execute(
+                f"SELECT id FROM utilisateurs WHERE {condition}",
+                (user_id, current_user_id, current_user_id)
+            )
+            if not cursor.fetchone():
+                return jsonify({"error": "User not accessible"}), 403
+    finally:
+        conn.close()
+
+    medecin = infos_ocr.get("medecin", {})
+    medicaments = infos_ocr.get("medicaments", [])
+
+    if not medicaments:
+        return jsonify({"error": "No medications provided"}), 422
+
+    conn = get_app_connection()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO ordonnances (
+                    utilisateur_id,
+                    description,
+                    medecin_nom,
+                    date_prescription,
+                    medicaments,
+                    statut,
+                    date_ajout
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+            """, (
+                user_id,
+                "Ordonnance créée via OCR",
+                medecin.get("nom"),
+                infos_ocr.get("date_prescription"),
+                json.dumps(medicaments),
+                "non_verifiee",
+                datetime.now()
+            ))
+            ordonnance_id = cursor.lastrowid
+            conn.commit()
+    finally:
+        conn.close()
+
+    return jsonify({
+        "message": "Ordonnance OCR créée",
+        "ordonnance_id": ordonnance_id,
+        "statut": "non_verifiee"
+    }), 201

--- a/backend/routes/ordonnances/verify_ordonnance.py
+++ b/backend/routes/ordonnances/verify_ordonnance.py
@@ -1,0 +1,45 @@
+from flask import Blueprint, request, jsonify
+from db_app import get_app_connection
+
+from routes.profile.profile_access import get_current_user_id
+
+verify_ordonnance_bp = Blueprint(
+    "verify_ordonnance",
+    __name__
+)
+
+@verify_ordonnance_bp.route("/ordonnances/verify", methods=["POST"])
+def verify_ordonnance():
+    current_user_id, error_response, status = get_current_user_id()
+    if error_response:
+        return error_response, status
+
+    data = request.get_json()
+    ordonnance_id = data.get("ordonnance_id")
+    action = data.get("action")
+
+    if action not in ["validate", "refuse"]:
+        return jsonify({"error": "Invalid action"}), 400
+
+    new_status = "active" if action == "validate" else "expiree"
+
+    conn = get_app_connection()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("""
+                UPDATE ordonnances
+                SET statut = %s
+                WHERE id = %s AND statut = 'non_verifiee'
+            """, (new_status, ordonnance_id))
+            conn.commit()
+
+            if cursor.rowcount == 0:
+                return jsonify({"error": "Ordonnance not found or already processed"}), 404
+    finally:
+        conn.close()
+
+    return jsonify({
+        "message": "Ordonnance traitée",
+        "ordonnance_id": ordonnance_id,
+        "statut": new_status
+    }), 200

--- a/backend/sql/app/database_app.sql
+++ b/backend/sql/app/database_app.sql
@@ -121,7 +121,7 @@ CREATE TABLE IF NOT EXISTS ordonnances (
     date_prescription DATE,
     date_expiration DATE,
     medicaments JSON,
-    statut ENUM('active', 'expiree', 'utilisee') DEFAULT 'active',
+    statut ENUM('non_verifiee', 'active', 'expiree', 'utilisee') DEFAULT 'active',
     FOREIGN KEY (utilisateur_id) REFERENCES utilisateurs(id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
Medical advice data was added to the backend using medicine_available.json, along with the necessary API routes and adjustments to ensure the data is correctly exposed and used by the application.

OCR routes were implemented to extract prescription information and store the retrieved data as prescriptions with a non_verifiee status. These prescriptions are persisted in the database and prepared to be sent to the pharmacist verification route for validation.